### PR TITLE
Specify license in gemspec

### DIFF
--- a/charlock_holmes-jruby.gemspec
+++ b/charlock_holmes-jruby.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.authors = ["Francis Chong"]
   s.date = Time.now.utc.strftime("%Y-%m-%d")
   s.email = %q{francis@ignition.hk}
+  s.license = 'MIT'
 
   s.files = `git ls-files`.split("\n")
   s.homepage = %q{http://github.com/siuying/charlock_holmes-jruby}


### PR DESCRIPTION
Hi 👋

The LICENSE appears to specify that this gem is [MIT licensed](https://mit-license.org/):

https://github.com/siuying/charlock_holmes-jruby/blob/b36cc0cc787f68bfda313cc6e542d953b87c2a6e/LICENSE#L1-L20

Including that data in the gemspec as well makes it easier for various tools to generate reports of all the dependencies in a project and their respective license.